### PR TITLE
fix(time): Make time property accessors return the correct values

### DIFF
--- a/src/js/MediaController.js
+++ b/src/js/MediaController.js
@@ -72,6 +72,42 @@ class MediaController {
         return {};
     }
 
+    /**
+     * Duration of the media currently playing. Proxies the current media
+     * plugin.
+     * @readonly
+     * @memberof MediaController
+     * @returns {Number|NaN}
+     */
+    get duration() {
+        if (!this.plugin) { return NaN; }
+
+        return this.plugin.duration;
+    }
+
+    /**
+     * Current playback position in the media. Proxies the current media
+     * plugin.
+     * @memberof MediaController
+     * @returns {Number|NaN}
+     */
+    get currentTime() {
+        if (!this.plugin) { return NaN; }
+
+        return this.plugin.currentTime;
+    }
+
+    /**
+     * Set the current playback position in the media. Proxies the current
+     * media plugin.
+     * @memberof MediaController
+     */
+    set currentTime(time) {
+        if (!this.plugin) { return; }
+
+        this.plugin.currentTime = time;
+    }
+
     getPluginFor(item) {
         return this.meister.pluginLoader.getPluginByItem(item).then((result) => {
             if (result.errorCode) {

--- a/src/js/Meister.js
+++ b/src/js/Meister.js
@@ -280,21 +280,21 @@ class Meister {
     }
 
     get duration() {
-        if (!this.playerPlugin) return null;
+        if (!this.mediaController) return null;
 
-        return this.playerPlugin.duration;
+        return this.mediaController.duration;
     }
 
     get currentTime() {
-        if (!this.playerPlugin) return null;
+        if (!this.mediaController) return null;
 
-        return this.playerPlugin.currentTime;
+        return this.mediaController.currentTime;
     }
 
     set currentTime(time) {
-        if (!this.playerPlugin) return;
+        if (!this.mediaController) return;
 
-        this.playerPlugin.currentTime = time;
+        this.mediaController.currentTime = time;
     }
 
     get isFullscreen() {

--- a/src/js/Parallel.js
+++ b/src/js/Parallel.js
@@ -139,6 +139,23 @@ class Parallel extends MediaPlugin {
         }
     }
 
+    get duration() {
+         if (!this.plugin) { return NaN; }
+
+         return this.plugin.duration;
+     }
+
+     get currentTime() {
+         if (!this.plugin) { return NaN; }
+
+         return this.plugin.currentTime;
+     }
+
+     set currentTime(time) {
+         if (!this.plugin) { return; }
+         this.plugin.currentTime = time;
+     }
+
     unload() {
         super.unload();
 

--- a/src/js/plugin-types/Media.js
+++ b/src/js/plugin-types/Media.js
@@ -18,6 +18,47 @@ class Media extends ProtoPlugin {
     }
 
     /**
+     * Get the duration of the media.
+     * Method should be implemented by the inheriting class.
+     * @readonly
+     * @memberof Media
+     * @returns {Number|NaN}
+     */
+    get duration() {
+        if (this.meister.debugEnabled) {
+            console.error(`${this.name} does not provide a duration getter.`);
+        }
+
+        return NaN;
+    }
+
+    /**
+     * Get the playback position in the media.
+     * Method should be implemented by the inheriting class.
+     * @readonly
+     * @memberof Media
+     * @returns {Number|NaN}
+     */
+    get currentTime() {
+        if (this.meister.debugEnabled) {
+            console.error(`${this.name} does not provide a currentTime getter.`);
+        }
+
+        return NaN;
+    }
+
+    /**
+     * Set the playback position in the media.
+     * Method should be implemented by the inheriting class.
+     * @memberof Media
+     */
+    set currentTime(time) {
+        if (this.meister.debugEnabled) {
+            console.error(`${this.name} does not provide a currentTime setter.`);
+        }
+    }
+
+    /**
      * Process is for reading metadata/parsing
      */
     process(item) {
@@ -37,7 +78,11 @@ class Media extends ProtoPlugin {
         if (Number.isFinite(item.startPosition)) {
             this.startPosition = item.startPosition;
         }
+
         this.on('playerLoadedMetadata', () => this.playerLoadedMetadata());
+        this.on('_playerTimeUpdate', this._onPlayerTimeUpdate.bind(this));
+        this.on('_playerSeek', this._onPlayerSeek.bind(this));
+        this.on('requestSeek', this.onRequestSeek.bind(this));
 
         this.blockSeekForward = !!item.blockSeekForward;
     }
@@ -53,6 +98,18 @@ class Media extends ProtoPlugin {
                 forcedStart: true,
             });
         }
+    }
+
+    _onPlayerTimeUpdate() {
+        console.error(`${this.name} does not implement '_onPlayerTimeUpdate', event ignored.`);
+    }
+
+    _onPlayerSeek() {
+        console.error(`${this.name} does not implement '_onPlayerSeek', event ignored.`);
+    }
+
+    onRequestSeek() {
+        console.error(`${this.name} does not implement 'onRequestSeek', event ignored.`);
     }
 
     /**


### PR DESCRIPTION
*IMPORTANT* Please review/merge all plugin changes before approving this one. Also, it might be a good idea to start peer dependencies before releasing these changes as packages.

Previously we used the playerPlugin as the source of currentTime and
duration information. However, due to the nature of various media
plugins it became apparent that the raw media element was ill suited for
requesting these properties. This patch changes the flow so that the
duration getter, and the currentTime getter/setter pair now go to active
plugin to fetch the relevant values.

Closes #36